### PR TITLE
Create a new quiz

### DIFF
--- a/src/main/java/com/example/QuizTask/Quiz.java
+++ b/src/main/java/com/example/QuizTask/Quiz.java
@@ -1,6 +1,6 @@
 package com.example.QuizTask;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 
@@ -11,7 +11,6 @@ public class Quiz {
     @Id
     @Column(name = "id", nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonIgnore
     private Long id;
 
 
@@ -67,7 +66,22 @@ public class Quiz {
     @Column(name = "options")
     @Size(min = 4)
     @OrderColumn
-    private List<String>  options;
+    private List<String> options;
+
+    @Column
+    @NotNull
+    @NotEmpty
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private int answer;
+
+
+    public int getAnswer() {
+        return answer;
+    }
+
+    public void setAnswer(int answer) {
+        this.answer = answer;
+    }
 
     public Long getId() {
         return id;
@@ -76,8 +90,6 @@ public class Quiz {
     public void setId(Long id) {
         this.id = id;
     }
-
-
 
 
 }

--- a/src/main/java/com/example/QuizTask/QuizController.java
+++ b/src/main/java/com/example/QuizTask/QuizController.java
@@ -17,7 +17,27 @@ public class QuizController {
     }
 
     @PostMapping("/api/quiz")
-    public  ResponseEntity<?> postRecipes(@RequestParam() String answer) {
+    public  ResponseEntity<?> postAnswer(@RequestParam() String answer) {
         return quizService.saveAnswer(answer);
+    }
+
+    @PostMapping("/api/quizzes")
+    public  ResponseEntity<?> createQuestionUser(@RequestBody() Quiz quiz) {
+        return quizService.createQuestion(quiz);
+    }
+
+    @GetMapping("/api/quizzes")
+    public  ResponseEntity<?> getQuestion() {
+        return quizService.getQuestions();
+    }
+
+    @GetMapping("/api/quiz/{id}")
+    public ResponseEntity<?> getById(@PathVariable long id) {
+        return quizService.getQuestionById(id);
+    }
+
+    @PostMapping("/api/quizzes/{id}/solve")
+    public  ResponseEntity<?> postAnswerWithId(@PathVariable long id, @RequestParam() int answer) {
+        return quizService.getSolveWithId(id, answer);
     }
 }

--- a/src/main/java/com/example/QuizTask/QuizService.java
+++ b/src/main/java/com/example/QuizTask/QuizService.java
@@ -5,12 +5,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 public class QuizService {
 
     Quiz quiz = new Quiz();
+    long id = 1;
+    List<Quiz> list = new ArrayList<>();
 
     public ResponseEntity<?> saveAnswer(String answer) {
         Feedback feedback = new Feedback();
@@ -31,5 +34,43 @@ public class QuizService {
         quiz.setText("What is depicted on the Java logo?");
         quiz.setOptions(List.of(new String[]{"Robot", "Tea leaf", "Cup of coffee", "Bug"}));
         return new ResponseEntity<>(quiz, HttpStatus.OK);
+    }
+
+    public ResponseEntity<?> createQuestion(Quiz quiz) {
+        quiz.setId(id);
+        System.out.println(quiz.getAnswer());
+        id++;
+        list.add(quiz);
+        return new ResponseEntity<>(quiz, HttpStatus.OK);
+    }
+
+    public ResponseEntity<?> getQuestions() {
+        return new ResponseEntity<>(list, HttpStatus.OK);
+    }
+
+    public ResponseEntity<?> getQuestionById(long idUser) {
+        for (Quiz quiz : list) {
+            if (quiz.getId() == idUser) {
+                return new ResponseEntity<>(quiz, HttpStatus.OK);
+            }
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+
+    public ResponseEntity<?> getSolveWithId(long idUser, int answer) {
+        Feedback feedback = new Feedback();
+        for (Quiz quiz : list) {
+            if (quiz.getId() == idUser) {
+                if (quiz.getAnswer() == answer) {
+                    feedback.setSuccess(true);
+                    feedback.setFeedback("Congratulations, you're right!");
+                } else {
+                    feedback.setSuccess(false);
+                    feedback.setFeedback("Wrong answer! Please, try again.");
+                }
+                return new ResponseEntity<>(feedback, HttpStatus.OK);
+            }
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 }


### PR DESCRIPTION
To create a new quiz, the client needs to send a JSON as the request's body via POST to /api/quizzes. The JSON should contain the four fields: title (a string), text (a string), options (an array of strings) and answer (integer index of the correct option). At this moment, all the keys are optional.

Here is a new JSON quiz as an example:

{
  "title": "The Java Logo",
  "text": "What is depicted on the Java logo?",
  "options": ["Robot","Tea leaf","Cup of coffee","Bug"],
  "answer": 2
}
The answer equals 2 corresponds to the third item from the options array ("Cup of coffee").

The server response is a JSON with four fields: id, title, text and options. Here is an example.

{
  "id": 1,
  "title": "The Java Logo",
  "text": "What is depicted on the Java logo?",
  "options": ["Robot","Tea leaf","Cup of coffee","Bug"]
}
The id field is a generated unique integer identifier for the quiz. Also, the response may or may not include the answer field depending on your wishes. This is not very important for this operation.

At this moment, it is admissible if a creation request does not contain some quiz data. In the next stages, we will improve the service to avoid some server errors.

Get a quiz by id
To get a quiz by id, the client sends the GET request to /api/quizzes/{id}.

Here is a response example:

{
  "id": 1,
  "title": "The Java Logo",
  "text": "What is depicted on the Java logo?",
  "options": ["Robot","Tea leaf","Cup of coffee","Bug"]
}
The response must not include the answer field, otherwise, any user will be able to find the correct answer for any quiz. If the specified quiz does not exist, the server should return the 404 (Not found) status code.

Get all quizzes
To get all existing quizzes in the service, the client sends the GET request to /api/quizzes.

The response contains a JSON array of quizzes like the following:

[
  {
    "id": 1,
    "title": "The Java Logo",
    "text": "What is depicted on the Java logo?",
    "options": ["Robot","Tea leaf","Cup of coffee","Bug"]
  },
  {
    "id": 2,
    "title": "The Ultimate Question",
    "text": "What is the answer to the Ultimate Question of Life, the Universe and Everything?",
    "options": ["Everything goes right","42","2+2=4","11011100"]
  }
]
The response must not include the answer field, otherwise, any user will be able to find the correct answer for any quiz. If there are no quizzes, the service returns an empty JSON array: [].

In both cases, the status code is 200 (OK).

Solving a quiz
To solve the quiz, the client sends a POST request to /api/quizzes/{id}/solve and passes the answer parameter in the content. This parameter is the index of a chosen option from options array. As before, it starts from zero.

The service returns a JSON with two fields: success (true or false) and feedback (just a string). There are three possible responses.

If the passed answer is correct (e.g., POST to /api/quizzes/1/solve with content answer=2): {"success":true,"feedback":"Congratulations, you're right!"} If the answer is incorrect (e.g., POST to /api/quizzes/1/solve with content answer=1): {"success":false,"feedback":"Wrong answer! Please, try again."} If the specified quiz does not exist, the server returns the 404 (Not found) status code. You can write any other strings in the feedback field, but the names of fields and the true/false values must match this example.